### PR TITLE
DOC: Add installation notes for Linux OS

### DIFF
--- a/INSTALL.rst.txt
+++ b/INSTALL.rst.txt
@@ -61,7 +61,7 @@ To perform an inplace build that can be run from the source folder run::
 
     python setup.py build_ext --inplace -j 4
 
-Note that, due to the way most Linux distributions are handling the Python 3 migration, Linux may have to replace the ``python`` command with ``python3``. See `here <https://packaging.python.org/tutorials/installing-packages/>`_
+Note that, due to the way most Linux distributions are handling the Python 3 migration, Linux may have to replace the ``python`` command with ``python3``. See `Requirements for Installing Packages <https://packaging.python.org/tutorials/installing-packages/>`_ for more details.
 
 The number of build jobs can also be specified via the environment variable
 NPY_NUM_BUILD_JOBS.

--- a/INSTALL.rst.txt
+++ b/INSTALL.rst.txt
@@ -61,6 +61,8 @@ To perform an inplace build that can be run from the source folder run::
 
     python setup.py build_ext --inplace -j 4
 
+Note that, due to the way most Linux distributions are handling the Python 3 migration, Linux may have to replace the ``python`` command with ``python3``. See `here <https://packaging.python.org/tutorials/installing-packages/>`_
+
 The number of build jobs can also be specified via the environment variable
 NPY_NUM_BUILD_JOBS.
 


### PR DESCRIPTION
Linux systems that have both Python 2.7 and Python 3.5 and up should use python3 setup.py instead of python setup.py to install numpy.